### PR TITLE
[FEAT] 빌려준 텃밭

### DIFF
--- a/atoms/category.ts
+++ b/atoms/category.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+const category = atom({
+  key: 'category',
+  default: '전체',
+});
+export default category;

--- a/atoms/category.ts
+++ b/atoms/category.ts
@@ -1,5 +1,6 @@
 import { atom } from 'recoil';
-const category = atom({
+type ICategory = '전체' | '거래중' | '거래완료';
+const category = atom<ICategory>({
   key: 'category',
   default: '전체',
 });

--- a/atoms/category.ts
+++ b/atoms/category.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-type ICategory = '전체' | '거래중' | '거래완료';
+export type ICategory = '전체' | '거래중' | '거래완료';
 const category = atom<ICategory>({
   key: 'category',
   default: '전체',

--- a/components/page/mypage/Category.tsx
+++ b/components/page/mypage/Category.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import styled from 'styled-components';
+import { useRecoilState } from 'recoil';
+import category from '../../../atoms/category';
 type ICategory = '전체' | '거래중' | '거래완료';
 const CategoryArray: ICategory[] = ['전체', '거래중', '거래완료'];
 
 const Category = () => {
-  const [category, setCategory] = useState<ICategory>('전체');
+  const [cate, setCate] = useRecoilState<ICategory>(category);
   return (
     <AnimatePresence>
       <Container>
@@ -13,11 +14,11 @@ const Category = () => {
           <StateName
             key={idx}
             onClick={() => {
-              setCategory(state);
+              setCate(state);
             }}
           >
             {state}
-            {category === state ? <GreenLine layoutId="line" /> : null}
+            {cate === state ? <GreenLine layoutId="line" /> : null}
           </StateName>
         ))}
       </Container>

--- a/components/page/mypage/Category.tsx
+++ b/components/page/mypage/Category.tsx
@@ -28,7 +28,9 @@ const GreenLine = styled(motion.div)`
   position: absolute;
   top: 34px;
   width: 100%;
-  border: 1.8px solid #005452;
+  z-index: 9999;
+  height: 3px;
+  background-color: #005452;
 `;
 const Container = styled.div`
   display: flex;

--- a/components/page/mypage/ItemMaker.tsx
+++ b/components/page/mypage/ItemMaker.tsx
@@ -1,23 +1,14 @@
-import styled from 'styled-components';
-import { LikeItemData } from '../../../pages/mypage/likes';
+import { GroundData } from '../../../pages';
 import Img from '../../common/Img';
-import { useState } from 'react';
-
 import {
   Container,
   ImageAndText,
   HeartAndInfo,
-  Heart,
   Info,
   Title,
   TextContainer,
 } from './ItemStyle';
-
-export const LikeItems = ({ props }: { props: LikeItemData }) => {
-  const [like, setLike] = useState(true);
-  const clickHandler = () => {
-    setLike((prev) => !prev);
-  };
+export const ItemMaker = ({ props }: { props: GroundData }) => {
   return (
     <>
       <Container>
@@ -32,13 +23,6 @@ export const LikeItems = ({ props }: { props: LikeItemData }) => {
           </TextContainer>
         </ImageAndText>
         <HeartAndInfo>
-          <Heart onClick={clickHandler}>
-            <Img
-              src={like ? '/clickedHeart.svg' : '/Heart.svg'}
-              width={35}
-              height={35}
-            />
-          </Heart>
           <Info>
             35m<sup>2</sup> | ♡{props.like_count}
           </Info>

--- a/components/page/mypage/ItemMaker.tsx
+++ b/components/page/mypage/ItemMaker.tsx
@@ -16,10 +16,10 @@ export const ItemMaker = ({ props }: { props: GroundData }) => {
           <Img src={props.image} width={100} height={100} />
           <TextContainer>
             <Title>{props.name}</Title>
-            <p>
+            <div>
               <div>{props.location}</div>
               <div>{props.price}원</div>
-            </p>
+            </div>
           </TextContainer>
         </ImageAndText>
         <HeartAndInfo>

--- a/components/page/mypage/ItemStyle.tsx
+++ b/components/page/mypage/ItemStyle.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+
+const Container = styled.div`
+  display: flex;
+  border-bottom: 2px solid #f4f4f4;
+  padding: 20px;
+  width: '100vw';
+  align-items: 'center';
+`;
+const ImageAndText = styled.div`
+  display: flex;
+  flex-basis: 85%;
+`;
+const HeartAndInfo = styled.div`
+  margin-top: 25px;
+  display: flex;
+  flex-basis: 15%;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+const TextContainer = styled.div`
+  padding-left: 20px;
+  font-weight: 600;
+  font-size: 11px;
+  color: #878b93;
+`;
+const Title = styled.div`
+  font-size: 23px;
+  font-weight: 500;
+  color: #000000;
+`;
+const Info = styled.div`
+  font-weight: 500;
+  font-size: 12px;
+  color: #bab8b5;
+`;
+const Heart = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+export {
+  Container,
+  ImageAndText,
+  HeartAndInfo,
+  Heart,
+  Info,
+  Title,
+  TextContainer,
+};

--- a/pages/mypage/borrowed.tsx
+++ b/pages/mypage/borrowed.tsx
@@ -1,11 +1,23 @@
+import axios from 'axios';
+import { useQuery } from 'react-query';
+import { GroundData } from '..';
+import { GroundItem } from '../../components/page/home';
 import Category from '../../components/page/mypage/Category';
 import { Header } from '../../components/page/mypage/Header';
+import { ItemMaker } from '../../components/page/mypage/ItemMaker';
 
-export default function borrowed() {
+function getData() {
+  return axios.get('/data/ground.json').then((res) => res.data);
+}
+export default function Borrowed() {
+  const { data } = useQuery<GroundData[]>(['likes'], getData);
   return (
     <>
       <Header title={'빌려준 텃밭'} />
       <Category />
+      {data?.map((info, idx) => (
+        <ItemMaker props={info} key={idx} />
+      ))}
     </>
   );
 }

--- a/pages/mypage/borrowed.tsx
+++ b/pages/mypage/borrowed.tsx
@@ -1,16 +1,26 @@
 import axios from 'axios';
 import { useQuery } from 'react-query';
+import { useRecoilValue } from 'recoil';
 import { GroundData } from '..';
+import category, { ICategory } from '../../atoms/category';
 import { GroundItem } from '../../components/page/home';
 import Category from '../../components/page/mypage/Category';
 import { Header } from '../../components/page/mypage/Header';
 import { ItemMaker } from '../../components/page/mypage/ItemMaker';
-
-function getData() {
-  return axios.get('/data/ground.json').then((res) => res.data);
+import {
+  getBorrowedTrading,
+  getBorrowedComplete,
+  getBorrowedEntire,
+} from '../../public/data/borrowed';
+function getData(cat: ICategory) {
+  if (cat == '거래중') return getBorrowedTrading().then((res) => res.data);
+  else if (cat == '거래완료')
+    return getBorrowedComplete().then((res) => res.data);
+  else return getBorrowedEntire().then((res) => res.data);
 }
 export default function Borrowed() {
-  const { data } = useQuery<GroundData[]>(['likes'], getData);
+  const cat = useRecoilValue(category);
+  const { data } = useQuery<GroundData[]>(['likes', cat], () => getData(cat));
   return (
     <>
       <Header title={'빌려준 텃밭'} />

--- a/pages/mypage/index.tsx
+++ b/pages/mypage/index.tsx
@@ -15,7 +15,7 @@ import { useRouter } from 'next/dist/client/router';
 export default function Mypage() {
   const router = useRouter();
   function handleClick(where: string) {
-    router.push(`${window.location.pathname}/${where}`);
+    router.push(`${window.location.pathname}${where}`);
   }
 
   const ImageLists = [

--- a/public/data/borrowed.ts
+++ b/public/data/borrowed.ts
@@ -1,0 +1,101 @@
+import { GroundData } from '../../pages';
+interface Ires {
+  data: GroundData[];
+}
+export async function getBorrowedTrading(): Promise<Ires> {
+  return await new Promise((resolve) => {
+    return setTimeout(() => {
+      const result = {
+        data: [
+          {
+            name: '민지네 텃밭',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 3,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138488-ab6862b0-7ac8-4092-b154-9466726eab45.png',
+          },
+          {
+            name: '중앙농장',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 15,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138498-ad33f399-9f58-4267-99ab-b080e80b643a.png',
+          },
+        ],
+      };
+      resolve(result);
+    }, 2000);
+  });
+}
+export async function getBorrowedComplete(): Promise<Ires> {
+  return await new Promise((resolve) => {
+    return setTimeout(() => {
+      const result = {
+        data: [
+          {
+            name: '의제네 텃밭',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 3,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138488-ab6862b0-7ac8-4092-b154-9466726eab45.png',
+          },
+          {
+            name: '서울농장',
+            location: '부산광역시 중구',
+            price: 10000,
+            like_count: 15,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138498-ad33f399-9f58-4267-99ab-b080e80b643a.png',
+          },
+        ],
+      };
+      resolve(result);
+    }, 2000);
+  });
+}
+export async function getBorrowedEntire(): Promise<Ires> {
+  return await new Promise((resolve) => {
+    return setTimeout(() => {
+      const result = {
+        data: [
+          {
+            name: '민지네 텃밭',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 3,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138488-ab6862b0-7ac8-4092-b154-9466726eab45.png',
+          },
+          {
+            name: '중앙농장',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 15,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138498-ad33f399-9f58-4267-99ab-b080e80b643a.png',
+          },
+          {
+            name: '의제네 텃밭',
+            location: '서울특별시 동작구',
+            price: 10000,
+            like_count: 3,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138488-ab6862b0-7ac8-4092-b154-9466726eab45.png',
+          },
+          {
+            name: '서울농장',
+            location: '부산광역시 중구',
+            price: 10000,
+            like_count: 15,
+            image:
+              'https://user-images.githubusercontent.com/12531340/203138498-ad33f399-9f58-4267-99ab-b080e80b643a.png',
+          },
+        ],
+      };
+      resolve(result);
+    }, 2000);
+  });
+}


### PR DESCRIPTION
## **Changes**
빌려준 텃밭
- [x]  :초록색 라인에 공백이 있던 오류 해결
- [x] : 빌려준 텃밭, 빌린 텃밭에서 렌더링에 사용할 itemMaker, 컴포넌트 분리
- [x] : category 상태를 관리하기 위한 category atom 추가
- [x] : Category에 recoil 적용하여 category state변경
- [x] : 각 카테고리별 mock api작성(응답시간 2초)
- [x] : 카테고리별 api 연결
## **After To-do**

- [ ]  : 빌린 텃밭에도 동일한 작업 필요함